### PR TITLE
修复meta.size获取错误长度问题

### DIFF
--- a/src/IoTSharp.Data.Taos/Driver/TDengineDriver.cs
+++ b/src/IoTSharp.Data.Taos/Driver/TDengineDriver.cs
@@ -256,7 +256,13 @@ namespace TDengineDriver
 
         public static List<TDengineMeta> FetchFields(IntPtr res)
         {
+            // const int fieldSize = 68;
+
             List<TDengineMeta> metas = new List<TDengineMeta>();
+            if (res == IntPtr.Zero)
+            {
+                return metas;
+            }
 
             int fieldCount = FieldCount(res);
             IntPtr fieldsPtr = taos_fetch_fields(res);
@@ -264,14 +270,13 @@ namespace TDengineDriver
             for (int i = 0; i < fieldCount; ++i)
             {
                 int offset = i * (int)TaosField.STRUCT_SIZE;
-#if NET45
-                taosField field = (taosField)Marshal.PtrToStructure(fieldsPtr + offset,typeof(taosField));
-#else 
-                taosField field = Marshal.PtrToStructure<taosField>(fieldsPtr + offset);
-#endif 
-                TDengineMeta meta = new TDengineMeta() { name = Encoding.Default.GetString(field.name)?.TrimEnd('\0'), size = field.bytes, type = field.type };
+                TDengineMeta meta = new TDengineMeta();
+                meta.name = Marshal.PtrToStringAnsi(fieldsPtr + offset);
+                meta.type = Marshal.ReadByte(fieldsPtr + offset + (int)TaosField.TYPE_OFFSET);
+                meta.size = Marshal.ReadInt16(fieldsPtr + offset + (int)TaosField.BYTES_OFFSET);
                 metas.Add(meta);
             }
+
 
             return metas;
         }


### PR DESCRIPTION
修复当字段类型为binary的时候,meta第一次获取meta.size,后面内容长度发生更改后,依然还是使用第一次meta.size的问题