### PR TITLE
结构体需要跟taosc保持一致,所以换一种方式进行判断

### DIFF
--- a/src/Example/Program.cs
+++ b/src/Example/Program.cs
@@ -20,7 +20,7 @@ namespace TaosADODemo
             string database = "db_" + DateTime.Now.ToString("yyyyMMddHHmmss");
             var builder = new TaosConnectionStringBuilder()
             {
-                DataSource = "taos",
+                DataSource = "airleaderserver",
                 DataBase = database,
                 Username = "root",
                 Password = "taosdata",

--- a/src/IoTSharp.Data.Taos/Driver/TDengineDriver.cs
+++ b/src/IoTSharp.Data.Taos/Driver/TDengineDriver.cs
@@ -140,7 +140,6 @@ namespace TDengineDriver
         public IntPtr error;
         public Int64 u;
         public uint allocated;
-        public bool is_string;
     }
 
 
@@ -164,7 +163,6 @@ namespace TDengineDriver
 
         // line number, or the values number in buffer 
         public int num;
-        public bool is_string;
     }
 
     /// <summary>

--- a/src/IoTSharp.Data.Taos/Driver/TaosBind.cs
+++ b/src/IoTSharp.Data.Taos/Driver/TaosBind.cs
@@ -260,7 +260,6 @@ namespace TDengineDriver
             bind.buffer_length = length;
             bind.length = lenPtr;
             bind.is_null = IntPtr.Zero;
-            bind.is_string = true;
 
             return bind;
         }
@@ -281,7 +280,6 @@ namespace TDengineDriver
             bind.buffer_length = length;
             bind.length = lenPtr;
             bind.is_null = IntPtr.Zero;
-            bind.is_string = true;
 
             return bind;
         }
@@ -324,7 +322,7 @@ namespace TDengineDriver
         {
             foreach (TAOS_BIND bind in binds)
             {
-                if (bind.is_string)
+                if (bind.buffer_type == (int)TDengineDataType.TSDB_DATA_TYPE_NCHAR || bind.buffer_type == (int)TDengineDataType.TSDB_DATA_TYPE_BINARY)
                     Marshal.FreeCoTaskMem(bind.buffer);
                 else
                     Marshal.FreeHGlobal(bind.buffer);

--- a/src/IoTSharp.Data.Taos/Driver/TaosMultiBind.cs
+++ b/src/IoTSharp.Data.Taos/Driver/TaosMultiBind.cs
@@ -479,7 +479,6 @@ namespace TDengineDriver
             multiBind.length = lengthArr;
             multiBind.is_null = nullArr;
             multiBind.num = elementCount;
-            multiBind.is_string = true;
 
             return multiBind;
         }
@@ -531,7 +530,6 @@ namespace TDengineDriver
             multiBind.length = lengthArr;
             multiBind.is_null = nullArr;
             multiBind.num = elementCount;
-            multiBind.is_string = true;
 
             return multiBind;
         }
@@ -575,7 +573,7 @@ namespace TDengineDriver
         {
             foreach (TAOS_MULTI_BIND bind in mBinds)
             {
-                if (bind.is_string)
+                if (bind.buffer_type == (int)TDengineDataType.TSDB_DATA_TYPE_NCHAR || bind.buffer_type == (int)TDengineDataType.TSDB_DATA_TYPE_BINARY)
                     Marshal.FreeCoTaskMem(bind.buffer);
                 else
                     Marshal.FreeHGlobal(bind.buffer);


### PR DESCRIPTION
TaosBind和TaosMultiBind必须跟taosc结构体保持一致,不能增加字段.所以更改为使用buffer_type判断,针对字符串类型进行释放